### PR TITLE
Fix service installation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,15 @@ chmod +x install_service.sh
 ```
 
 - 서비스로 실행하면 컴퓨터를 시작할 때마다 자동으로 실행됩니다.
+- 필요한 `~/Library/LaunchAgents` 폴더가 없으면 자동으로 생성합니다.
 - 기본 재고 확인 간격: 1분
 - 기본 생존 알림 간격: 60분
 - 시간 간격을 변경하려면 `config.sh` 파일의 `DEFAULT_CHECK_INTERVAL`과 `DEFAULT_HEARTBEAT_INTERVAL` 값을 수정하세요.
+
+### run_monitor.sh와 install_service.sh의 차이
+
+- `run_monitor.sh`: 즉시 모니터링을 시작하며, 실행 시 또는 명령줄 인자로 시간 간격을 지정할 수 있습니다. 로그 파일은 실행 시점의 타임스탬프를 포함한 이름으로 `logs` 폴더에 저장됩니다.
+- `install_service.sh`: macOS LaunchAgent 서비스를 생성하여 백그라운드에서 모니터링을 실행합니다. 기본 간격을 사용하며 컴퓨터를 재시작해도 자동으로 동작합니다.
 
 ## 서비스 관리
 

--- a/config.sh
+++ b/config.sh
@@ -8,8 +8,11 @@ DEFAULT_HEARTBEAT_INTERVAL=60
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/venv"
 LOG_DIR="$SCRIPT_DIR/logs"
-mkdir -p "$LOG_DIR"
-PLIST_PATH="$HOME/Library/LaunchAgents/com.keycult.monitor.plist"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_PATH="$PLIST_DIR/com.keycult.monitor.plist"
+
+# Ensure required directories exist
+mkdir -p "$LOG_DIR" "$PLIST_DIR"
 
 # 환경 변수
 export PYTHONIOENCODING=utf-8

--- a/install_service.sh
+++ b/install_service.sh
@@ -14,7 +14,7 @@ check_environment
 mkdir -p "$LOG_DIR"
 
 # 실행 권한 부여
-chmod +X "$SCRIPT_DIR"
+chmod +x "$SCRIPT_DIR"
 chmod +x "$SCRIPT_DIR/run_monitor.sh"
 chmod +x "$SCRIPT_DIR/uninstall_service.sh"
 


### PR DESCRIPTION
## Summary
- ensure `~/Library/LaunchAgents` directory exists when installing service
- fix executable permission command in `install_service.sh`
- document that the service script creates `~/Library/LaunchAgents`
- explain difference between run_monitor and install_service

## Testing
- `bash -n install_service.sh`
- `bash -n run_monitor.sh`
- `bash -n config.sh`
- `bash -n install.sh`
- `python -m py_compile keycult_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_684514deb784832e97e3b3c36e696e38